### PR TITLE
Fix getimagesizefromstring() says Read error!

### DIFF
--- a/src/LfmItem.php
+++ b/src/LfmItem.php
@@ -149,7 +149,12 @@ class LfmItem
     public function dimensions()
     {
         if ($this->isImage() && !$this->isSvg()) {
-            list($width, $height) = getimagesizefromstring($this->get());
+            try {
+                list($width, $height) = getimagesizefromstring($this->get());
+            } catch (\ErrorException $e){
+                return false;
+            }
+            
             return $width . 'x' . $height;
         }
 


### PR DESCRIPTION
If the file has read error when getting the dimension, then catch the error, and don't write out the dimensions.

#### Summary of the change:

Catch the getimagesizefromstring() error.
