### PR TITLE
Fixed download when file storage is not local

### DIFF
--- a/src/Controllers/DownloadController.php
+++ b/src/Controllers/DownloadController.php
@@ -13,7 +13,7 @@ class DownloadController extends LfmController
 
         try {
             if (Storage::disk($this->helper->config('disk'))->exists($filepath)) {
-                return response()->download($this->lfm->setName(request('file'))->path('absolute'));
+                return Storage::disk($this->helper->config('disk'))->download($filepath);
             }
         } catch (\Exception $e) {
             // Do not need to throw the exception


### PR DESCRIPTION
The file download generates a 404 error when using a file storage which is not local like S3 - so I used the Storage download function instead of the response download.
