### PR TITLE
Ability to disable demo and errors routes

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -241,7 +241,7 @@ class Lfm
      *
      * @return void
      */
-    public static function routes()
+    public static function routes($options = [])
     {
         $middleware = [CreateDefaultFolder::class, MultiUser::class];
         $as = 'mafftor.lfm.';
@@ -256,10 +256,12 @@ class Lfm
             ]);
 
             // display integration error messages
-            Route::get('/errors', [
-                'uses' => 'LfmController@getErrors',
-                'as' => 'getErrors',
-            ]);
+            if ($options['errors'] ?? true) {
+                Route::get('/errors', [
+                    'uses' => 'LfmController@getErrors',
+                    'as' => 'getErrors',
+                ]);
+            }
 
             // upload
             Route::any('/upload', [
@@ -343,7 +345,9 @@ class Lfm
                 'as' => 'getDelete',
             ]);
 
-            Route::get('/demo', 'DemoController@index');
+            if ($options['demo'] ?? true) {
+                Route::get('/demo', 'DemoController@index');
+            }
         });
     }
 }


### PR DESCRIPTION
Most of users dont need this routes in production environment, so they can use it like that:
```
//routes/web.php

Route::group(['prefix' => 'filemanager'], function () {
    \Mafftor\LaravelFileManager\Lfm::routes(app()->isProduction() ? ['errors' => false, 'demo' => false] : []);
});
```